### PR TITLE
Change output message format and use ec2 instance role

### DIFF
--- a/src/Log/Engine/CloudwatchLog.php
+++ b/src/Log/Engine/CloudwatchLog.php
@@ -68,7 +68,10 @@ class CloudwatchLog extends BaseLog
 
   public function log($level, $message, array $context = [])
   {
-    $this->logger($level)->log($level, $message, $context);
+    $message = $this->_format($message, $context);
+    $output = date('Y-m-d H:i:s') . ' ' . ucfirst($level) . ': ' . $message . "\n";
+
+    $this->logger($level)->log($level, $output, $context);
     return true;
   }
 }

--- a/src/Log/Engine/CloudwatchLog.php
+++ b/src/Log/Engine/CloudwatchLog.php
@@ -21,13 +21,15 @@ class CloudwatchLog extends BaseLog
 
     // aws
     'aws' => [
-      'region' => 'eu-central-1',
+/**
+      'region' => env('AWS_DEFAULT_REGION', 'eu-central-1'),
       'version' => 'latest',
       'credentials' => [
         'key' => 'your AWS key',
         'secret' => 'your AWS secret',
         //'token' => 'your AWS session token',
       ]
+*/
     ]
   ];
 


### PR DESCRIPTION
- output message format

Convert some types to string type
https://github.com/cakephp/cakephp/blob/3.6.15/src/Log/Engine/BaseLog.php#L84-L114
and ...

system time. 
 same format on FileLogEngine/ConsoleLogEngine.
 The time displayed by CloudWatch Log is the time CloudWatch Log received.
 It is better for the application to have log output time.

level string.
 multi level output to same `streamName`.

- use ec2 instance role

use ec2 instance role don't need `aws.credentials` .
It is necessary to set as below in config/app.php
```
...
  'Log' => [
      'debug' => [
          ...
         'aws' => [
           'credentials' => null // !!
         ]
          ...
       ]
  ]
```
